### PR TITLE
Fix long connection times.

### DIFF
--- a/moto/state_connection.py
+++ b/moto/state_connection.py
@@ -38,8 +38,8 @@ class StateConnection(SimpleMessageConnection):
             None
         ] * MOT_MAX_GR  # Max controllable groups
 
-        self._joint_feedback_ex = None
-        self._robot_status = None
+        self._joint_feedback_ex: JointFeedbackEx = None
+        self._robot_status: RobotStatus = None
         self._initial_response: Event = Event()
         self._lock: Lock = Lock()
 
@@ -67,7 +67,7 @@ class StateConnection(SimpleMessageConnection):
     def add_joint_feedback_ex_msg_callback(self, callback: Callable):
         self._joint_feedback_ex_callbacks.append(callback)
 
-    def start(self, timeout: Float = 5) -> None:
+    def start(self, timeout: Float = 5.0) -> None:
         self._tcp_client.connect()
         self._worker_thread.start()
         if not self._initial_response.wait(timeout):


### PR DESCRIPTION
A more elegant solution than PR #4.

`StateConnection.start()` is now a blocking call until one of each message type has been received. This also has the effect that `Moto(start_state_connection=True)` is blocking. 

This prevents the user from trying to access parameters, such as `StateConnection.robot_status()` or `Moto.state.robot_status()`, before they have been instantiated. 

